### PR TITLE
Restore old id

### DIFF
--- a/scenes/networkPornPros.py
+++ b/scenes/networkPornPros.py
@@ -32,7 +32,7 @@ class PornprosSpider(BaseSceneScraper):
         'date': '//div[@class="tlcSpecs"]/span[@class="tlcSpecsDate"]/span[@class="tlcDetailsValue"]/text() | //*[@class="updatedDate"]/text() | //div[@id="t2019-stime"]//span/text()',
         'performers': '//div[@class="sceneCol sceneColActors"]//a/text() | //div[@class="sceneCol scenePerformers"]//a/text() | //div[@class="pornstarName"]/text() | //div[@id="slick_DVDInfoPerformerCarousel"]//a/text() | //div[@id="slick_sceneInfoPlayerPerformerCarousel"]//a/text() | //div[@id="t2019-models"]/a/text()',
         'tags': '//div[@class="sceneCol sceneColCategories"]//a/text() | //div[@class="sceneCategories"]//a/text() | //p[@class="dvdCol"]/a/text()',
-        'external_id': 'video\\/(.+)',
+        'external_id': 'video\/(.+)',
         'trailer': '//video//source/@src',
         'pagination': '/?page=%s'
     }
@@ -50,9 +50,6 @@ class PornprosSpider(BaseSceneScraper):
                 meta['date'] = dateparser.parse(
                     scene.css('div::attr(data-date)').get()).isoformat()
 
-            if scene.css('div::attr(data-video-id)').get() is not None:
-                meta['id'] = scene.css('div::attr(data-video-id)').get()
-
             yield scrapy.Request(url=self.format_link(response, link), callback=self.parse_scene, meta=meta)
 
     def get_image(self, response):
@@ -66,6 +63,3 @@ class PornprosSpider(BaseSceneScraper):
 
         if response.xpath('//img[@id="no-player-image"]') is not None:
             return response.xpath('//img[@id="no-player-image"]/@src').get()
-
-    def get_id(self, response):
-        return slugify(self.get_title(response))


### PR DESCRIPTION
Fix for already existed scenes, like
https://metadataapi.net/scenes/casting-couch-x-lily-larimar-1
https://metadataapi.net/scenes/casting-couch-x-lily-larimar

you can't access scene by that id from `data-video-id`
https://castingcouch-x.com/video/68323