### PR TITLE
Team Skeet main site support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -128,3 +128,5 @@ dmypy.json
 # Pyre type checker
 .pyre/
 /.vs/slnx.sqlite
+/.vs/VSWorkspaceState.json
+/.vs/Scrapers/v16/.suo

--- a/scenes/networkTeamSkeet.py
+++ b/scenes/networkTeamSkeet.py
@@ -12,117 +12,141 @@ movies_nav_text = "newestMovies"
 videos_nav_text = "latestVideos"
 movies_content_text = "moviesContent"
 videos_content_text = "videosContent"
+ts_nav_template = "newestMovies"
 
 link_to_info = {
     "SLM-organic-b75inmn9fu": {
         "site": "Sis Loves Me",
         "navText": movies_nav_text,
-        "contentText": movies_content_text
+        "contentText": movies_content_text,
+        "useTeamSkeet": "no"
+
     },
     "FS-organic-1rstmyhj44": {
         "site": "Family Strokes",
         "navText": movies_nav_text,
-        "contentText": movies_content_text
+        "contentText": movies_content_text,
+        "useTeamSkeet": "no"
     },
     "ts-organic-iiiokv9kyo": {
         "site": "Team Skeet",
         "navText": videos_nav_text,
-        "contentText": videos_content_text
+        "contentText": videos_content_text,
+        "useTeamSkeet": "no"
     },
     "mylf-organic-2uxkybtwvv": {
         "site": "MYLF",
         "navText": videos_nav_text,
-        "contentText": videos_content_text
+        "contentText": videos_content_text,
+        "useTeamSkeet": "no"
     },
     "EXS-organic-ooJ4duo8": {
         "site": "Exxxtra Small",
         "navText": movies_nav_text,
-        "contentText": movies_content_text
+        "contentText": movies_content_text,
+        "useTeamSkeet": "yes"
     },
     "FOS-organic-n5oaginage": {
         "site": "Foster Tapes",
         "navText": movies_nav_text,
-        "contentText": movies_content_text
+        "contentText": movies_content_text,
+        "useTeamSkeet": "no"
     },
     "DSW-organic-dfangeym88": {
         "site": "Daughter Swap",
         "navText": movies_nav_text,
-        "contentText": movies_content_text
+        "contentText": movies_content_text,
+        "useTeamSkeet": "no"
     },
     "DC-organic-w8xs8e0dv3": {
         "site": "Dad Crush",
         "navText": movies_nav_text,
-        "contentText": movies_content_text
+        "contentText": movies_content_text,
+        "useTeamSkeet": "no"
     },
     "MSL-organic-ws9h564all": {
         "site": "ShopLyfter MYLF",
         "navText": movies_nav_text,
-        "contentText": movies_content_text
+        "contentText": movies_content_text,
+        "useTeamSkeet": "no"
     },
     "SHL-organic-driobt7t0f": {
         "site": "ShopLyfter",
         "navText": movies_nav_text,
-        "contentText": movies_content_text
+        "contentText": movies_content_text,
+        "useTeamSkeet": "no"
     },
     "PVM-organic-rg7wwuc7uh": {
         "site": "PervMom",
         "navText": movies_nav_text,
-        "contentText": movies_content_text
+        "contentText": movies_content_text,
+        "useTeamSkeet": "no"
     },
     "TMZ-organic-958spxinbs": {
         "site": "Thickumz",
         "navText": movies_nav_text,
-        "contentText": movies_content_text
+        "contentText": movies_content_text,
+        "useTeamSkeet": "no"
     },
     "LAS-organic-whlghevsfs": {
         "site": "Little Asians",
         "navText": movies_nav_text,
-        "contentText": movies_content_text
+        "contentText": movies_content_text,
+        "useTeamSkeet": "no"
     },
     "BFFS-organic-7o68xoev0j": {
         "site": "BFFs",
         "navText": movies_nav_text,
-        "contentText": movies_content_text
+        "contentText": movies_content_text,
+        "useTeamSkeet": "no"
     },
     "TLBC-organic-w8bw4yp9io": {
         "site": "Teens Love Black Cocks",
         "navText": movies_nav_text,
-        "contentText": movies_content_text
+        "contentText": movies_content_text,
+        "useTeamSkeet": "no"
     },
     "BCG-organic-dhed18vuav": {
         "site": "Black Valley Girls",
         "navText": movies_nav_text,
-        "contentText": movies_content_text
+        "contentText": movies_content_text,
+        "useTeamSkeet": "no"
     },
     "organic-fuf-eiBei5In": {
         "site": "Freeuse Fantasy",
         "navText": movies_nav_text,
-        "contentText": movies_content_text
+        "contentText": movies_content_text,
+        "useTeamSkeet": "no"
     },
     "Organic-pna-OongoaF1": {
         "site": "PervNana",
         "navText": movies_nav_text,
-        "contentText": movies_content_text
+        "contentText": movies_content_text,
+        "useTeamSkeet": "no"
     },
     "organic-Baepha2v-1": {
         "site": "Not My Grandpa",
         "navText": movies_nav_text,
-        "contentText": movies_content_text
+        "contentText": movies_content_text,
+        "useTeamSkeet": "no"
     },
     "organic-mylfdom-ieH7cuos": {
         "site": "MYLFDom",
         "navText": movies_nav_text,
-        "contentText": movies_content_text
+        "contentText": movies_content_text,
+        "useTeamSkeet": "no"
     },
     "organic-1-goide6Xo": {
         "site": "BBC Paradise",
         "navText": movies_nav_text,
-        "contentText": movies_content_text
+        "contentText": movies_content_text,
+        "useTeamSkeet": "no"
     },
     "organic-alm-Od3Iqu9I": {
         "site": "Anal Mom",
         "navText": movies_nav_text,
-        "contentText": movies_content_text
+        "contentText": movies_content_text,
+        "useTeamSkeet": "no"
     }
 }
 
@@ -132,6 +156,10 @@ def format_nav_url(link, start, limit):
     return nav_format.format(link=link, start=start,
                              limit=limit, navText=link_to_info[link]["navText"])
 
+def format_nav_url_TS(condensedSiteName, limit):
+    nav_format_ts = "https://store2.psmcdn.net/ts-elastic-d5cat0jl5o-videoscontent/_search?q=site.seo.seoSlug:%22{condensedSiteName}%22&sort=publishedDate:desc&size={limit}"
+    return nav_format_ts.format(condensedSiteName= condensedSiteName,
+                             limit=limit)
 
 def format_scene_url(link, sceneId):
     content_format = "https://store.psmcdn.net/{link}/{contentText}/{sceneId}.json"
@@ -155,10 +183,15 @@ class TeamSkeetNetworkSpider(BaseSceneScraper):
 
     def start_requests(self):
         start = "aaaaaaaa"
-        limit = 250
+        limit = 450
         for linkName, siteInfo in link_to_info.items():
             meta = {'site': siteInfo['site']}
-            yield scrapy.Request(url=format_nav_url(linkName, start, limit), callback=self.get_scenes, meta=meta)
+            useTS = siteInfo['useTeamSkeet']
+            if useTS=="yes":
+                condenseSiteName = siteInfo['site'].lower().replace(" ","")
+                yield scrapy.Request(url=format_nav_url_TS(condenseSiteName, limit), callback=self.get_scenes_TS, meta=meta)
+            else:
+                yield scrapy.Request(url=format_nav_url(linkName, start, limit), callback=self.get_scenes, meta=meta)
 
     def parse_scene(self, response):
         data = response.json()
@@ -166,10 +199,7 @@ class TeamSkeetNetworkSpider(BaseSceneScraper):
         item['title'] = data['title']
         item['description'] = data['description']
         item['image'] = data['img']
-        if 'tags' in data:
-            item['tags'] = data['tags']
-        else:
-            item['tags'] = []
+        item['tags'] = []
         item['id'] = data['id']
         if 'video' in data:
             item['trailer'] = 'https://videodelivery.net/' + \
@@ -213,3 +243,47 @@ class TeamSkeetNetworkSpider(BaseSceneScraper):
                 scene_id = scene["id"]
                 scene_url = format_scene_url(site_link, scene_id)
                 yield scrapy.Request(url=scene_url, callback=self.parse_scene, meta=response.meta)
+
+    def get_scenes_TS(self, response):
+        scenes = response.json()
+        
+
+        for sceneItem in scenes['hits']['hits']:
+            sceneData = sceneItem['_source']
+            item = SceneItem()
+            item['title'] = sceneData['title']
+            item['description'] = sceneData['description']
+            item['image'] = sceneData['img']
+            item['id'] = sceneData['id']
+            item['trailer'] = sceneData['videoTrailer']
+            
+            item['url'] = response.url
+            item['network'] = self.network
+            item['parent'] = response.meta['site']
+
+            if 'publishedDate' in sceneData:
+                item['date'] = dateparser.parse(sceneData['publishedDate']).isoformat()
+            else:
+                item['date'] = datetime.now().isoformat()
+
+            if 'site' in sceneData:
+                if 'name' in sceneData['site']:
+                    item['site'] = sceneData['site']['name']
+                else:
+                    item['site'] = response.meta['site']
+            else:
+                item['site'] = response.meta['site']
+
+            item['performers'] = []
+            if 'models' in sceneData:
+                for model in sceneData['models']:
+                    item['performers'].append(model['modelName'])
+
+            item['tags'] = []
+            if 'tags' in sceneData:
+                for tag in sceneData['tags']:
+                    item['tags'].append(tag)
+            if self.debug:
+                print(item)
+            else:
+                yield item


### PR DESCRIPTION
Impl is slightly different as the search on the main site can just return a summary json for the site which can then yield all the scenes.
Added xtra config entry to the sites dictionary to determine whether it should use the main Team Skeet site.
Limit increased to 450 to cover older scenes. Tested final change (commented out except Exxxtra Small on main tests), so no comma issues should be present this time!