### PR TITLE
fix for TopWebModels trailers

### DIFF
--- a/scenes/networkTopWebModels.py
+++ b/scenes/networkTopWebModels.py
@@ -59,7 +59,7 @@ class TopWebModelsSpider(BaseSceneScraper):
             item['description'] = re.sub('<[^<]+?>', '', item['description']).strip()
             item['image'] = jsonentry['thumb']
             item['id'] = jsonentry['id']
-            item['trailer'] = jsonentry['trailer']
+            item['trailer'] = ''
             urltext = re.sub(r'[^A-Za-z0-9 ]+', '', jsonentry['title']).lower()
             urltext = urltext.replace("  "," ")
             urltext = urltext.replace(" ","-")


### PR DESCRIPTION
trailers were always empty, but scrapy was seeing the blank field as a list instead of empty string so api submit was failing