### PR TITLE
Lustery

### DIFF
--- a/scenes/siteLustery.py
+++ b/scenes/siteLustery.py
@@ -5,6 +5,9 @@ from tpdb.items import SceneItem
 from datetime import datetime
 import re
 
+# Call with -a max_id=1000
+# This needs to be increased over time
+
 class LusterySpider(BaseSceneScraper):
     name = 'Lustery'
     network = 'Lustery'
@@ -45,14 +48,6 @@ class LusterySpider(BaseSceneScraper):
     def get_next_page_url(self, base, page):
         return self.format_url(base, self.get_selector_map('pagination') % ((page-1) * 12))
 
-    # def get_scenes(self, response):
-    #     for scene in response.xpath("//a[contains(@href, '#video')]/@href").getall():
-    #         video_id = scene.split("-")[1]
-    #         yield scrapy.Request(
-    #             cookies={},
-    #             url=self.format_link(response, "/video-preview/" + video_id),
-    #             callback=self.parse_scene)
-
     def get_date(self, response):
         '''Date is not shown anywhere without logging in.
             Using the Unix timestamp of the poster image as the date'''
@@ -66,14 +61,10 @@ class LusterySpider(BaseSceneScraper):
     def start_requests(self):
         # Lustery doesn't allow you to see all pages without logging in.
         # Instead we guess at video ids up to maximum
-
-        MAX_ID = 1000 # This needs to be increased over time
-
         self.download_delay = 0.25 # Important as they will block you
         for url in self.start_urls:
-            for video_id in range(30, MAX_ID):
+            for video_id in range(30, self.max_id):
                 yield scrapy.Request(
                     cookies={},
                     url=url + "/video-preview/" + str(video_id),
                     callback=self.parse_scene)
-

--- a/scenes/siteLustery.py
+++ b/scenes/siteLustery.py
@@ -63,7 +63,7 @@ class LusterySpider(BaseSceneScraper):
         # Instead we guess at video ids up to maximum
         self.download_delay = 0.25 # Important as they will block you
         for url in self.start_urls:
-            for video_id in range(30, self.max_id):
+            for video_id in range(30, int(self.max_id)):
                 yield scrapy.Request(
                     cookies={},
                     url=url + "/video-preview/" + str(video_id),

--- a/scenes/siteLustery.py
+++ b/scenes/siteLustery.py
@@ -8,6 +8,7 @@ import re
 # Call with -a max_id=1000
 # This needs to be increased over time
 
+
 class LusterySpider(BaseSceneScraper):
     name = 'Lustery'
     network = 'Lustery'
@@ -55,7 +56,6 @@ class LusterySpider(BaseSceneScraper):
         if img_url is None:
             img_url = response.xpath('//div[@class="poster-with-video lazy-image"]/@data-src').get()
         timestamp = int(img_url.split("=")[1])
-
         return datetime.fromtimestamp(timestamp)
 
     def start_requests(self):

--- a/scenes/siteLustery.py
+++ b/scenes/siteLustery.py
@@ -1,7 +1,5 @@
 import scrapy
-from scrapy.selector import Selector
 from tpdb.BaseSceneScraper import BaseSceneScraper
-from tpdb.items import SceneItem
 from datetime import datetime
 import re
 
@@ -47,7 +45,7 @@ class LusterySpider(BaseSceneScraper):
         return [p.strip() for p in couple.split("&")]
 
     def get_next_page_url(self, base, page):
-        return self.format_url(base, self.get_selector_map('pagination') % ((page-1) * 12))
+        return self.format_url(base, self.get_selector_map('pagination') % ((page - 1) * 12))
 
     def get_date(self, response):
         '''Date is not shown anywhere without logging in.
@@ -61,7 +59,7 @@ class LusterySpider(BaseSceneScraper):
     def start_requests(self):
         # Lustery doesn't allow you to see all pages without logging in.
         # Instead we guess at video ids up to maximum
-        self.download_delay = 0.25 # Important as they will block you
+        self.download_delay = 0.25  # Important as they will block you
         for url in self.start_urls:
             for video_id in range(30, int(self.max_id)):
                 yield scrapy.Request(

--- a/scenes/siteLustery.py
+++ b/scenes/siteLustery.py
@@ -1,0 +1,79 @@
+import scrapy
+from scrapy.selector import Selector
+from tpdb.BaseSceneScraper import BaseSceneScraper
+from tpdb.items import SceneItem
+from datetime import datetime
+import re
+
+class LusterySpider(BaseSceneScraper):
+    name = 'Lustery'
+    network = 'Lustery'
+    parent = 'Lustery'
+
+    start_urls = ["https://lustery.com"]
+
+    selector_map = {
+        'title': '//div[@class="title"]/h3/text()',
+        'description': '//div[@class="video-popup-info"]/div[@class="description"]//text()',
+        'tags': '//div[@class="video-popup-info"]//div[@class="tags"]/a//text()',
+        'date': '',
+        'external_id': 'video-preview/(.+)',
+        'pagination': 'videos?start=%s',
+    }
+
+    def get_image(self, response):
+        image_url = response.xpath('//video-js/@data-poster').get()
+        if image_url is None:
+            image_url = response.xpath('//div[@class="poster-with-video lazy-image"]/@data-src').get()
+        return image_url
+
+    def get_trailer(self, response):
+        video_id = response.url.split("/")[-1]
+        return self.format_link(response, "play_preview_video_mp4/" + video_id)
+
+    def get_performers(self, response):
+        couple = response.xpath('//div[contains(@class,"couple")]/a//text()').get()
+        if couple is None:
+            # Some of the early videos don't include the couple features
+            # Instead use a heuristic on the description
+            #  - Find capitalized words in the format 'Name and Name'
+            desc = self.get_description(response)
+            couple = re.search(r'[A-Z][a-z]+ (and|&) [A-Z][a-z]+', desc).group()
+            return [couple.split()[0], couple.split()[1]]
+        return [p.strip() for p in couple.split("&")]
+
+    def get_next_page_url(self, base, page):
+        return self.format_url(base, self.get_selector_map('pagination') % ((page-1) * 12))
+
+    # def get_scenes(self, response):
+    #     for scene in response.xpath("//a[contains(@href, '#video')]/@href").getall():
+    #         video_id = scene.split("-")[1]
+    #         yield scrapy.Request(
+    #             cookies={},
+    #             url=self.format_link(response, "/video-preview/" + video_id),
+    #             callback=self.parse_scene)
+
+    def get_date(self, response):
+        '''Date is not shown anywhere without logging in.
+            Using the Unix timestamp of the poster image as the date'''
+        img_url = self.get_image(response)
+        if img_url is None:
+            img_url = response.xpath('//div[@class="poster-with-video lazy-image"]/@data-src').get()
+        timestamp = int(img_url.split("=")[1])
+
+        return datetime.fromtimestamp(timestamp)
+
+    def start_requests(self):
+        # Lustery doesn't allow you to see all pages without logging in.
+        # Instead we guess at video ids up to maximum
+
+        MAX_ID = 1000 # This needs to be increased over time
+
+        self.download_delay = 0.25 # Important as they will block you
+        for url in self.start_urls:
+            for video_id in range(30, MAX_ID):
+                yield scrapy.Request(
+                    cookies={},
+                    url=url + "/video-preview/" + str(video_id),
+                    callback=self.parse_scene)
+


### PR DESCRIPTION
Scraper for Lustery which doesn't require login.

- Without login, you can only see page 1 of the video list. Video pages are however referenced by an incrementing numeric id (with some gaps), so you can iterate all values up to a maximum.
- This could be easily adapted to use the login (which is free)
- Needs to be scraped reasonably slowly or you'll get banned.