### PR TITLE
lustery remove blurred images

### DIFF
--- a/scenes/siteLustery.py
+++ b/scenes/siteLustery.py
@@ -27,6 +27,7 @@ class LusterySpider(BaseSceneScraper):
         image_url = response.xpath('//video-js/@data-poster').get()
         if image_url is None:
             image_url = response.xpath('//div[@class="poster-with-video lazy-image"]/@data-src').get()
+        image_url = image_url.replace("_20_blurred", "")
         return image_url
 
     def get_trailer(self, response):


### PR DESCRIPTION
Discovered some images are blurred on the lustery site. Removing `_blurred` from the image url gives you the full res version.