### PR TITLE
Fixes for Python 3.8 w/ dateparser and more formatting cleanup

### DIFF
--- a/performers/site5DollahPerformer.py
+++ b/performers/site5DollahPerformer.py
@@ -1,12 +1,17 @@
-import scrapy
 import re
-from datetime import datetime
-from dateutil.relativedelta import relativedelta
+import warnings
+import scrapy
 import dateparser
 from tpdb.BasePerformerScraper import BasePerformerScraper
 
+# Ignore dateparser warnings regarding pytz
+warnings.filterwarnings(
+    "ignore",
+    message="The localize method is no longer necessary, as this time zone supports the fold attribute",
+)
 
-class site5DollahPerformerSpider(BasePerformerScraper):
+
+class Site5DollahPerformerSpider(BasePerformerScraper):
     selector_map = {
         'name': '//h1/text()',
         'image': '//div[contains(@class,"model-page")]/div/div/img/@src',
@@ -18,7 +23,7 @@ class site5DollahPerformerSpider(BasePerformerScraper):
         'ethnicity': '//span[@class="item" and contains(text(),"Ethnicity")]/following-sibling::span[@class="value"][1]/text()',
         'birthday': '//span[@class="item" and contains(text(),"Dob")]/following-sibling::span[@class="value"][1]/text()',
         'pagination': '/models/page%s.html',
-        'external_id': 'models\/(.*).html'
+        'external_id': r'models/(.*).html'
     }
 
     name = '5DollahPerformer'
@@ -34,7 +39,7 @@ class site5DollahPerformerSpider(BasePerformerScraper):
         for performer in performers:
             yield scrapy.Request(
                 url=self.format_link(response, performer),
-                callback=self.parse_performer, meta={'site':'5Dollah'}
+                callback=self.parse_performer, meta={'site': '5Dollah'}
             )
 
     def get_gender(self, response):
@@ -43,19 +48,19 @@ class site5DollahPerformerSpider(BasePerformerScraper):
     def get_cupsize(self, response):
         if 'measurements' in self.selector_map:
             measurements = self.process_xpath(response, self.get_selector_map('measurements')).get()
-            if measurements and re.search('(.*-\d{2}-\d{2})', measurements):
-                measurements = measurements.replace(" ","").strip()
-                measurements = re.search('(.*-\d{2}-\d{2})', measurements).group(1)
+            if measurements and re.search(r'(.*-\d{2}-\d{2})', measurements):
+                measurements = measurements.replace(" ", "").strip()
+                measurements = re.search(r'(.*-\d{2}-\d{2})', measurements).group(1)
                 if measurements:
                     cupsize = re.search('(.*?)-.*', measurements).group(1)
                     if cupsize:
                         return cupsize.upper().strip()
-        return ''   
+        return ''
 
     def get_measurements(self, response):
         if 'measurements' in self.selector_map:
             measurements = self.process_xpath(response, self.get_selector_map('measurements')).get()
-            if measurements and re.search('\d{2}(?:[a-zA-Z]+)?-\d{2}-\d{2}', measurements):
+            if measurements and re.search(r'\d{2}(?:[a-zA-Z]+)?-\d{2}-\d{2}', measurements):
                 return measurements.strip()
         return ''
 
@@ -64,9 +69,9 @@ class site5DollahPerformerSpider(BasePerformerScraper):
             height = self.process_xpath(response, self.get_selector_map('height')).get()
             if height:
                 if "cms" in height.lower():
-                    height = re.search('(\d+)\s+?cm',height.lower()).group(1)
+                    height = re.search(r'(\d+)\s+?cm', height.lower()).group(1)
                     if height:
-                        height = height+"cm"
+                        height = height + "cm"
                         return height.strip()
         return ''
 
@@ -75,9 +80,9 @@ class site5DollahPerformerSpider(BasePerformerScraper):
             weight = self.process_xpath(response, self.get_selector_map('weight')).get()
             if weight:
                 if "kg" in weight.lower():
-                    weight = re.search('(\d+)\s+?kg',weight.lower()).group(1)
+                    weight = re.search(r'(\d+)\s+?kg', weight.lower()).group(1)
                     if weight:
-                        weight = weight+"kg"
+                        weight = weight + "kg"
                         return weight.strip()
         return ''
 
@@ -85,6 +90,4 @@ class site5DollahPerformerSpider(BasePerformerScraper):
         date = self.process_xpath(response, self.get_selector_map('birthday')).get()
         if date:
             return dateparser.parse(date.strip()).isoformat()
-        else:
-            return ''
-
+        return ''

--- a/performers/siteBaberoticaPerformer.py
+++ b/performers/siteBaberoticaPerformer.py
@@ -1,9 +1,14 @@
-import scrapy
 import re
-from datetime import datetime
-from dateutil.relativedelta import relativedelta
+import warnings
 import dateparser
+import scrapy
 from tpdb.BasePerformerScraper import BasePerformerScraper
+
+# Ignore dateparser warnings regarding pytz
+warnings.filterwarnings(
+    "ignore",
+    message="The localize method is no longer necessary, as this time zone supports the fold attribute",
+)
 
 
 class BaberoticaPerformerSpider(BasePerformerScraper):
@@ -25,7 +30,7 @@ class BaberoticaPerformerSpider(BasePerformerScraper):
         'cupsize': '//div[@id="model"]/div/strong[contains(text(),"Breasts")]/../following-sibling::div[1]/text()',
         'aliases': '//div[@id="model"]/div/strong[contains(text(),"Aliases")]/../following-sibling::div[1]/text()',
         'pagination': '/models/page/%s',
-        'external_id': 'model\/(.*)/'
+        'external_id': r'model\/(.*)/'
     }
 
     name = 'BaberoticaPerformer'
@@ -48,20 +53,18 @@ class BaberoticaPerformerSpider(BasePerformerScraper):
                 callback=self.parse_performer
             )
 
-
     def get_aliases(self, response):
-        image = self.process_xpath(response, self.get_selector_map('aliases')).get()
+        aliases = self.process_xpath(response, self.get_selector_map('aliases')).get()
         if aliases:
             aliases = aliases.split(", ").trim()
             return aliases
         return ''
 
-
     def get_measurements(self, response):
         if 'measurements' in self.selector_map:
             measurements = self.process_xpath(response, self.get_selector_map('measurements')).get()
-            if measurements and re.match('\d+.*?-.*?\d+.*?-.*?\d+', measurements):
-                measurements = measurements.replace("B","").replace("W","").replace("H","")
+            if measurements and re.match(r'\d+.*?-.*?\d+.*?-.*?\d+', measurements):
+                measurements = measurements.replace("B", "").replace("W", "").replace("H", "")
                 return measurements.strip()
         return ''
 
@@ -71,8 +74,8 @@ class BaberoticaPerformerSpider(BasePerformerScraper):
             if cupsize:
                 if 'measurements' in self.selector_map:
                     measurements = self.process_xpath(response, self.get_selector_map('measurements')).get()
-                    if measurements and re.match('\d+.*?-.*?\d+.*?-.*?\d+', measurements):
-                        breasts = re.search('(\d+).*?-.*?\d+.*?-.*?\d+',measurements).group(1)
+                    if measurements and re.match(r'\d+.*?-.*?\d+.*?-.*?\d+', measurements):
+                        breasts = re.search(r'(\d+).*?-.*?\d+.*?-.*?\d+', measurements).group(1)
                         cupsize = breasts.strip() + cupsize.strip()
                         if cupsize:
                             return cupsize.strip()
@@ -90,9 +93,9 @@ class BaberoticaPerformerSpider(BasePerformerScraper):
         if 'height' in self.selector_map:
             height = self.process_xpath(response, self.get_selector_map('height')).get()
             if height:
-                if "cm" in height and re.match('(\d+\s?cm)', height):
-                    height = re.search('(\d+\s?cm)', height).group(1).strip()
-                    height = height.replace(" ","")
+                if "cm" in height and re.match(r'(\d+\s?cm)', height):
+                    height = re.search(r'(\d+\s?cm)', height).group(1).strip()
+                    height = height.replace(" ", "")
                 if "0 ft" not in height:
                     return height.strip()
         return ''
@@ -102,8 +105,8 @@ class BaberoticaPerformerSpider(BasePerformerScraper):
             weight = self.process_xpath(response, self.get_selector_map('weight')).get()
             if weight:
                 if "kg" in weight:
-                    weight = re.search('(\d+\s?kg)', weight).group(1).strip()
-                    weight = weight.replace(" ","")
+                    weight = re.search(r'(\d+\s?kg)', weight).group(1).strip()
+                    weight = weight.replace(" ", "")
                 return weight.strip()
         return ''
 

--- a/performers/siteBrattyMILFPerformer.py
+++ b/performers/siteBrattyMILFPerformer.py
@@ -1,8 +1,6 @@
-import scrapy
 import re
-from datetime import datetime
-from dateutil.relativedelta import relativedelta
-import dateparser
+import scrapy
+
 from tpdb.BasePerformerScraper import BasePerformerScraper
 
 
@@ -15,7 +13,7 @@ class BrattyMILFPerformerSpider(BasePerformerScraper):
         'nationality': '//h5[contains(text(), "Location")]/following-sibling::p[1]/text()',
         'measurements': '//h5[contains(text(), "Figure")]/following-sibling::p[1]/text()',
         'pagination': '/model/gallery/%s',
-        'external_id': 'model\/(.*)/'
+        'external_id': r'model/(.*)/'
     }
 
     name = 'BrattyMILFPerformer'
@@ -43,8 +41,8 @@ class BrattyMILFPerformerSpider(BasePerformerScraper):
     def get_measurements(self, response):
         if 'measurements' in self.selector_map:
             measurements = self.process_xpath(response, self.get_selector_map('measurements')).get()
-            if measurements and re.match('\d+.*?-.*?\d+.*?-.*?\d+', measurements):
-                measurements = measurements.replace("B","").replace("W","").replace("H","")
+            if measurements and re.match(r'\d+.*?-.*?\d+.*?-.*?\d+', measurements):
+                measurements = measurements.replace("B", "").replace("W", "").replace("H", "")
                 return measurements.strip()
         return ''
 
@@ -54,8 +52,8 @@ class BrattyMILFPerformerSpider(BasePerformerScraper):
             if cupsize:
                 if 'measurements' in self.selector_map:
                     measurements = self.process_xpath(response, self.get_selector_map('measurements')).get()
-                    if measurements and re.match('\d+.*?-.*?\d+.*?-.*?\d+', measurements):
-                        breasts = re.search('(\d+).*?-.*?\d+.*?-.*?\d+',measurements).group(1)
+                    if measurements and re.match(r'\d+.*?-.*?\d+.*?-.*?\d+', measurements):
+                        breasts = re.search(r'(\d+).*?-.*?\d+.*?-.*?\d+', measurements).group(1)
                         cupsize = breasts.strip() + cupsize.strip()
                         if cupsize:
                             return cupsize.strip()

--- a/scenes/fillerEuroStunners.py
+++ b/scenes/fillerEuroStunners.py
@@ -1,14 +1,15 @@
 import re
 from datetime import datetime
+import tldextract
 import scrapy
 
 from tpdb.BaseSceneScraper import BaseSceneScraper
 from tpdb.items import SceneItem
 
-    # This site is being updated, but not for any sites that are needed.  A lot of the sites that were
-    # originally scraped from Data18 had further updates past where Data18 lost the 21Sextury feeds
-    # so this is just a one-time scrape to pull those additional scenes.  On this site they only
-    # range from the 2015-2020 or so timeframe
+# This site is being updated, but not for any sites that are needed.  A lot of the sites that were
+# originally scraped from Data18 had further updates past where Data18 lost the 21Sextury feeds
+# so this is just a one-time scrape to pull those additional scenes.  On this site they only
+# range from the 2015-2020 or so timeframe
 
 
 class EurostunnersFillerSpider(BaseSceneScraper):
@@ -18,23 +19,22 @@ class EurostunnersFillerSpider(BaseSceneScraper):
     url = 'https://eurostunners.com'
 
     paginations = [
-        ['/showcase/21%20Erotic%20Anal/{0}/','21 Erotic Anal', '21Sextury', 'Gamma Enterprises','2000-01-01T12:00:00','current'],
-        ['/showcase/21FootArt/{0}/','21FootArt', '21Sextury', 'Gamma Enterprises','2000-01-01T12:00:00','current'],
-        ['/showcase/Anal%20Teen%20Club/{0}/','Anal Teen Club', '21Sextury', 'Gamma Enterprises','2000-01-01T12:00:00','current'],
-        ['/showcase/Busty%20Fever/{0}/','Busty Fever', '21Sextury', 'Gamma Enterprises','2000-01-01T12:00:00','current'],
-        ['/showcase/Daily%20Sex%20Dose/{0}/','Daily Sex Dose', '21Sextury', 'Gamma Enterprises','2011-07-05T12:00:00','current'],
-        ['/showcase/DP%20Overload/{0}/','DP Overload', '21Sextury', 'Gamma Enterprises','2012-03-06T12:00:00','current'],
-        ['/showcase/Enslaved%20Gals/{0}/','Enslaved Gals', '21Sextury', 'Gamma Enterprises','2012-06-18T12:00:00','current'],
-        ['/showcase/Grandpas%20Fuck%20Teens/{0}/','Grandpas Fuck Teens', '21Sextury', 'Gamma Enterprises','2018-03-25T12:00:00','current'],
-        ['/showcase/Intermixed%20Sluts/{0}/','Intermixed Sluts', '21Sextury', 'Gamma Enterprises','2012-05-20T12:00:00','current'],
-        ['/showcase/Lust%20For%20Anal/{0}/','Lust For Anal', '21Sextury', 'Gamma Enterprises','2012-05-24T12:00:00','current'],
-        ['/showcase/Lusty%20Busty%20Chix/{0}/','Lusty Busty Chix', '21Sextury', 'Gamma Enterprises','2012-05-28T12:00:00','current'],
-        ['/showcase/Lusty%20Grandmas/{0}/','Lusty Grandmas', '21Sextury', 'Gamma Enterprises','2018-03-30T12:00:00','current'],
-        ['/showcase/Oral%20Quickies/{0}/','Oral Quickies', '21Sextury', 'Gamma Enterprises','2012-05-04T12:00:00','current'],
-        ['/showcase/Teach%20Me%20Fisting/{0}/','Teach Me Fisting', '21Sextury', 'Gamma Enterprises','2018-03-27T12:00:00','current'],
-        ['/showcase/Teen%20Bitch%20Club/{0}/','Teen Bitch Club', '21Sextury', 'Gamma Enterprises','2012-05-19T12:00:00','current'],
-
-        ['/showcase/Wifeys%20World/{0}/','Wifeys World', 'Wifeys World', 'Wifeys World','2000-01-01T12:00:00','current', 'https://pornstar-scenes.com/'],
+        ['/showcase/21%20Erotic%20Anal/{0}/', '21 Erotic Anal', '21Sextury', 'Gamma Enterprises', '2000-01-01T12:00:00', 'current'],
+        ['/showcase/21FootArt/{0}/', '21FootArt', '21Sextury', 'Gamma Enterprises', '2000-01-01T12:00:00', 'current'],
+        ['/showcase/Anal%20Teen%20Club/{0}/', 'Anal Teen Club', '21Sextury', 'Gamma Enterprises', '2000-01-01T12:00:00', 'current'],
+        ['/showcase/Busty%20Fever/{0}/', 'Busty Fever', '21Sextury', 'Gamma Enterprises', '2000-01-01T12:00:00', 'current'],
+        ['/showcase/Daily%20Sex%20Dose/{0}/', 'Daily Sex Dose', '21Sextury', 'Gamma Enterprises', '2011-07-05T12:00:00', 'current'],
+        ['/showcase/DP%20Overload/{0}/', 'DP Overload', '21Sextury', 'Gamma Enterprises', '2012-03-06T12:00:00', 'current'],
+        ['/showcase/Enslaved%20Gals/{0}/', 'Enslaved Gals', '21Sextury', 'Gamma Enterprises', '2012-06-18T12:00:00', 'current'],
+        ['/showcase/Grandpas%20Fuck%20Teens/{0}/', 'Grandpas Fuck Teens', '21Sextury', 'Gamma Enterprises', '2018-03-25T12:00:00', 'current'],
+        ['/showcase/Intermixed%20Sluts/{0}/', 'Intermixed Sluts', '21Sextury', 'Gamma Enterprises', '2012-05-20T12:00:00', 'current'],
+        ['/showcase/Lust%20For%20Anal/{0}/', 'Lust For Anal', '21Sextury', 'Gamma Enterprises', '2012-05-24T12:00:00', 'current'],
+        ['/showcase/Lusty%20Busty%20Chix/{0}/', 'Lusty Busty Chix', '21Sextury', 'Gamma Enterprises', '2012-05-28T12:00:00', 'current'],
+        ['/showcase/Lusty%20Grandmas/{0}/', 'Lusty Grandmas', '21Sextury', 'Gamma Enterprises', '2018-03-30T12:00:00', 'current'],
+        ['/showcase/Oral%20Quickies/{0}/', 'Oral Quickies', '21Sextury', 'Gamma Enterprises', '2012-05-04T12:00:00', 'current'],
+        ['/showcase/Teach%20Me%20Fisting/{0}/', 'Teach Me Fisting', '21Sextury', 'Gamma Enterprises', '2018-03-27T12:00:00', 'current'],
+        ['/showcase/Teen%20Bitch%20Club/{0}/', 'Teen Bitch Club', '21Sextury', 'Gamma Enterprises', '2012-05-19T12:00:00', 'current'],
+        ['/showcase/Wifeys%20World/{0}/', 'Wifeys World', 'Wifeys World', 'Wifeys World', '2000-01-01T12:00:00', 'current', 'https://pornstar-scenes.com/'],
     ]
 
     selector_map = {
@@ -44,7 +44,7 @@ class EurostunnersFillerSpider(BaseSceneScraper):
         'image': '//script[@type="application/ld+json"]/text()',
         'performers': '//h1/a[contains(@href,"model")]/text()',
         'tags': '//div[@class="card-body"]//a[contains(@href,"/tag/")]/text()',
-        'external_id': '.*\/(.+)\/$',
+        'external_id': r'.*/(.+)/$',
         'trailer': '//script[@type="application/ld+json"]/text()',
         'pagination': '/shoots/latest?page=%s'
     }
@@ -64,16 +64,9 @@ class EurostunnersFillerSpider(BaseSceneScraper):
                 todate = todate.isoformat()
             yield scrapy.Request(url=self.get_next_page_url(self.url, self.page, pagination),
                                  callback=self.parse,
-                                 meta={
-                                    'page': self.page,
-                                    'pagination': pagination,
-                                    'site': site,
-                                    'parent': parent,
-                                    'network': network,
-                                    'fromdate': fromdate,
-                                    'todate': todate},
-                headers=self.headers,
-                cookies=self.cookies)
+                                 meta={'page': self.page, 'pagination': pagination, 'site': site, 'parent': parent, 'network': network, 'fromdate': fromdate, 'todate': todate},
+                                 headers=self.headers,
+                                 cookies=self.cookies)
 
     def parse(self, response, **kwargs):
         if response.status == 200:
@@ -101,7 +94,6 @@ class EurostunnersFillerSpider(BaseSceneScraper):
             if re.search(self.get_selector_map('external_id'), scene):
                 yield scrapy.Request(url=self.format_link(response, scene), callback=self.parse_scene, meta=meta)
 
-
     def get_next_page_url(self, url, page, pagination):
         return self.format_url(url, pagination.format(page))
 
@@ -110,7 +102,7 @@ class EurostunnersFillerSpider(BaseSceneScraper):
             response, self.get_selector_map('title')).get()
         if title:
             if '"name"' in title:
-                title = re.search('Object\",\"name\":\s+\"(.*?)\"', title).group(1)
+                title = re.search(r'Object\",\"name\":\s+\"(.*?)\"', title).group(1)
                 if title:
                     return title.strip().title()
         return ''
@@ -120,7 +112,7 @@ class EurostunnersFillerSpider(BaseSceneScraper):
             response, self.get_selector_map('description')).get()
         if description:
             if '"description"' in description:
-                description = re.search('\"description\":\s+\"(.*?)\"', description).group(1)
+                description = re.search(r'\"description\":\s+\"(.*?)\"', description).group(1)
                 if description:
                     return description.strip()
         return ''
@@ -130,7 +122,7 @@ class EurostunnersFillerSpider(BaseSceneScraper):
             response, self.get_selector_map('date')).get()
         if date:
             if '"uploadDate"' in date:
-                date = re.search('\"uploadDate\":\s+\"(.*?)\"', date).group(1)
+                date = re.search(r'\"uploadDate\":\s+\"(.*?)\"', date).group(1)
                 if date:
                     return date.strip()
         return ''
@@ -140,7 +132,7 @@ class EurostunnersFillerSpider(BaseSceneScraper):
             response, self.get_selector_map('image')).get()
         if image:
             if '"thumbnailUrl"' in image:
-                image = re.search('\"thumbnailUrl\":\s+\"(.*?)\"', image).group(1)
+                image = re.search(r'\"thumbnailUrl\":\s+\"(.*?)\"', image).group(1)
                 if image:
                     if image[0:2] == "//":
                         image = "https:" + image
@@ -153,14 +145,13 @@ class EurostunnersFillerSpider(BaseSceneScraper):
             response, self.get_selector_map('trailer')).get()
         if trailer:
             if '"contentUrl"' in trailer:
-                trailer = re.search('\"contentUrl\":\s+\"(.*?)\"', trailer).group(1)
+                trailer = re.search(r'\"contentUrl\":\s+\"(.*?)\"', trailer).group(1)
                 if trailer:
                     if trailer[0:2] == "//":
                         trailer = "https:" + trailer
                     trailer = trailer.replace('https:https:', 'https:')
                     return trailer.strip()
         return ''
-
 
     def get_site(self, response):
         meta = response.meta
@@ -170,7 +161,7 @@ class EurostunnersFillerSpider(BaseSceneScraper):
 
     def get_network(self, response):
         meta = response.meta
-        print (f'Network Meta: {meta}')
+        print(f'Network Meta: {meta}')
         if meta['network']:
             return meta['network']
         return tldextract.extract(response.url).domain
@@ -180,8 +171,6 @@ class EurostunnersFillerSpider(BaseSceneScraper):
         if meta['parent']:
             return meta['parent']
         return tldextract.extract(response.url).domain
-
-
 
     def parse_scene(self, response):
         meta = response.meta

--- a/scenes/moviesAdultDVDEmpire.py
+++ b/scenes/moviesAdultDVDEmpire.py
@@ -1,10 +1,11 @@
 import re
+import copy
+from datetime import datetime
 import dateparser
 import scrapy
-import copy
-from datetime import datetime, timedelta
 from tpdb.BaseSceneScraper import BaseSceneScraper
 from tpdb.items import SceneItem
+
 
 class AdultDVDEmpireMovieSpider(BaseSceneScraper):
     name = 'AdultDVDEmpireMovie'
@@ -21,7 +22,7 @@ class AdultDVDEmpireMovieSpider(BaseSceneScraper):
         'image': '//link[@rel="image_src"]/@href',
         'performers': '//strong[contains(text(),"Starring")]/following-sibling::a/div/u/text()',
         'tags': '//strong[contains(text(),"Categories")]/following-sibling::a/text()',
-        'external_id': '\/(\d+)\/',
+        'external_id': r'/(\d+)/',
         'trailer': '',
         'pagination': '/new-release-porn-movies.html?page=%s&media=2'
     }
@@ -33,22 +34,18 @@ class AdultDVDEmpireMovieSpider(BaseSceneScraper):
             if re.search(self.get_selector_map('external_id'), scene):
                 yield scrapy.Request(url=self.format_link(response, scene), callback=self.parse_scene)
 
-
     def get_parent(self, response):
         studio = response.xpath('//div[@class="item-info"]/a[@Label="Studio" or @label="Studio"]/text()').get()
         if studio:
             return studio.strip()
-        else:
-            return ""
+        return ""
 
     def get_site(self, response):
         site = response.xpath(
             '//div[contains(@class,"title-rating-section")]/div/h1/text()').get()
         if site:
             return "Movie: " + site.strip()
-        else:
-            return ""
-
+        return ""
 
     def get_description(self, response):
 
@@ -67,7 +64,6 @@ class AdultDVDEmpireMovieSpider(BaseSceneScraper):
                 return list(map(lambda x: x.strip().title(), tags))
         return []
 
-
     def get_date(self, response):
         date = self.process_xpath(response, self.get_selector_map('date')).get()
         if date:
@@ -80,7 +76,6 @@ class AdultDVDEmpireMovieSpider(BaseSceneScraper):
                 return datetime.now().isoformat()
 
         return dateparser.parse(date.strip()).isoformat()
-
 
     def parse_scene(self, response):
         item = SceneItem()
@@ -143,7 +138,6 @@ class AdultDVDEmpireMovieSpider(BaseSceneScraper):
             item['parent'] = self.parent
         else:
             item['parent'] = self.get_parent(response)
-
 
         moviescenes = response.xpath('//a[contains(@name,"scene") and @class="anchor"]/following-sibling::div[@class="row"]')
         if moviescenes:

--- a/scenes/network5kPorn.py
+++ b/scenes/network5kPorn.py
@@ -1,8 +1,15 @@
+import warnings
 import dateparser
 import scrapy
 from scrapy.http import HtmlResponse
 
 from tpdb.BaseSceneScraper import BaseSceneScraper
+
+# Ignore dateparser warnings regarding pytz
+warnings.filterwarnings(
+    "ignore",
+    message="The localize method is no longer necessary, as this time zone supports the fold attribute",
+)
 
 
 class FiveKPornSpider(BaseSceneScraper):

--- a/scenes/networkAdultCentro.py
+++ b/scenes/networkAdultCentro.py
@@ -1,4 +1,6 @@
 import re
+import sys
+import warnings
 import json
 import html
 import string
@@ -8,6 +10,12 @@ import scrapy
 
 from tpdb.BaseSceneScraper import BaseSceneScraper
 from tpdb.items import SceneItem
+
+# Ignore dateparser warnings regarding pytz
+warnings.filterwarnings(
+    "ignore",
+    message="The localize method is no longer necessary, as this time zone supports the fold attribute",
+)
 
 
 class NetworkAdultCentroSpider(BaseSceneScraper):
@@ -64,13 +72,13 @@ class NetworkAdultCentroSpider(BaseSceneScraper):
                 ah = re.search(r'"ah":"(.*?)"', appscript).group(1)
                 aet = re.search(r'"aet":([0-9]+?),', appscript).group(1)
                 if ah and aet:
-                    print(f'ah: {ah}')
-                    print(f'aet: {aet}')
+                    # ~ print(f'ah: {ah}')
+                    # ~ print(f'aet: {aet}')
                     token = ah[::-1] + "/" + str(aet)
-                    print(f'Token: {token}')
+                    # ~ print(f'Token: {token}')
 
             if not token:
-                quit()
+                sys.exit()
             else:
                 meta['token'] = token
 
@@ -150,7 +158,6 @@ class NetworkAdultCentroSpider(BaseSceneScraper):
 
     def get_scenes(self, response):
         meta = response.meta
-        global json
         jsondata = json.loads(response.text)
         jsondata = jsondata['response']['collection']
 
@@ -165,7 +172,6 @@ class NetworkAdultCentroSpider(BaseSceneScraper):
     def parse_scene(self, response):
         meta = response.meta
         item = SceneItem()
-        global json
 
         jsondata = response.text
         jsondata = jsondata.replace('\r\n', '')

--- a/scenes/networkAdultCentro.py
+++ b/scenes/networkAdultCentro.py
@@ -1,18 +1,16 @@
-import scrapy
-
-from tpdb.BaseSceneScraper import BaseSceneScraper
 import re
-import dateparser
 import json
 import html
 import string
 from urllib.parse import urlparse
-import time
+import dateparser
+import scrapy
 
-from datetime import datetime
+from tpdb.BaseSceneScraper import BaseSceneScraper
 from tpdb.items import SceneItem
 
-class networkAdultCentroSpider(BaseSceneScraper):
+
+class NetworkAdultCentroSpider(BaseSceneScraper):
     name = 'AdultCentro'
 
     sites = {
@@ -54,18 +52,8 @@ class networkAdultCentroSpider(BaseSceneScraper):
     }
 
     def start_requests(self):
-        # ~ link = ''
-        # ~ if self.site:
-            # ~ if self.site in self.sites:
-                # ~ link = self.sites[self.site]
-
-        # ~ if not link:
-            # ~ print(f'Scraper requires a site with -a site=xxxxx flag.')
-            # ~ print(f'Current available options are {self.sites}')
-            # ~ self.crawler.engine.close_spider(self, reason='No Site Selected')
-        # ~ else:
         for link in self.sites:
-            yield scrapy.Request(link + '/videos/', callback=self.start_requests_2, meta={'link':link})
+            yield scrapy.Request(link + '/videos/', callback=self.start_requests_2, meta={'link': link})
 
     def start_requests_2(self, response):
 
@@ -85,7 +73,6 @@ class networkAdultCentroSpider(BaseSceneScraper):
                 quit()
             else:
                 meta['token'] = token
-
 
             url = self.get_next_page_url(meta['link'], self.page, meta['token'])
             meta['page'] = self.page
@@ -176,7 +163,7 @@ class networkAdultCentroSpider(BaseSceneScraper):
             yield scrapy.Request(scene_url, callback=self.parse_scene, headers=self.headers, cookies=self.cookies, meta=meta)
 
     def parse_scene(self, response):
-        meta=response.meta
+        meta = response.meta
         item = SceneItem()
         global json
 
@@ -399,7 +386,6 @@ class networkAdultCentroSpider(BaseSceneScraper):
             modelurl = "https://facialcasting.com/sapi/{}/model.getModelContent?_method=model.getModelContent&tz=-4&transitParameters[contentId]={}".format(meta['token'], item['id'])
             meta['item'] = item
             yield scrapy.Request(modelurl, callback=self.get_performers_json, meta=meta)
-
 
     def get_performers_json(self, response):
         meta = response.meta

--- a/scenes/networkBadoinkVr.py
+++ b/scenes/networkBadoinkVr.py
@@ -1,9 +1,15 @@
+import warnings
 from datetime import datetime
-
 import dateparser
 import scrapy
 
 from tpdb.BaseSceneScraper import BaseSceneScraper
+
+# Ignore dateparser warnings regarding pytz
+warnings.filterwarnings(
+    "ignore",
+    message="The localize method is no longer necessary, as this time zone supports the fold attribute",
+)
 
 
 class BadoinkVrSpider(BaseSceneScraper):

--- a/scenes/networkCherryPimps.py
+++ b/scenes/networkCherryPimps.py
@@ -1,7 +1,14 @@
+import warnings
 import dateparser
 import scrapy
 
 from tpdb.BaseSceneScraper import BaseSceneScraper
+
+# Ignore dateparser warnings regarding pytz
+warnings.filterwarnings(
+    "ignore",
+    message="The localize method is no longer necessary, as this time zone supports the fold attribute",
+)
 
 
 class CherryPimpsSpider(BaseSceneScraper):

--- a/scenes/networkTeamSkeet.py
+++ b/scenes/networkTeamSkeet.py
@@ -112,7 +112,7 @@ link_to_info = {
         "v2": False
     },
     "Organic-pna-OongoaF1": {
-        "site": "PervNana",
+        "site": "Perv Nana",
         "navText": movies_nav_text,
         "contentText": movies_content_text,
         "v2": False

--- a/scenes/networkVegasDreamworks.py
+++ b/scenes/networkVegasDreamworks.py
@@ -1,10 +1,17 @@
 import re
+import warnings
 from datetime import date
 import tldextract
 import dateparser
 import scrapy
 
 from tpdb.BaseSceneScraper import BaseSceneScraper
+
+# Ignore dateparser warnings regarding pytz
+warnings.filterwarnings(
+    "ignore",
+    message="The localize method is no longer necessary, as this time zone supports the fold attribute",
+)
 
 
 def get_scenedate(scene):

--- a/scenes/networkVna.py
+++ b/scenes/networkVna.py
@@ -1,8 +1,15 @@
 import re
+import warnings
 import dateparser
 import scrapy
 
 from tpdb.BaseSceneScraper import BaseSceneScraper
+
+# Ignore dateparser warnings regarding pytz
+warnings.filterwarnings(
+    "ignore",
+    message="The localize method is no longer necessary, as this time zone supports the fold attribute",
+)
 
 
 class VnaNetworkSpider(BaseSceneScraper):

--- a/scenes/networkWankz.py
+++ b/scenes/networkWankz.py
@@ -1,9 +1,15 @@
 import re
-
+import warnings
 import dateparser
 import scrapy
 
 from tpdb.BaseSceneScraper import BaseSceneScraper
+
+# Ignore dateparser warnings regarding pytz
+warnings.filterwarnings(
+    "ignore",
+    message="The localize method is no longer necessary, as this time zone supports the fold attribute",
+)
 
 
 class NetworkWankzSpider(BaseSceneScraper):

--- a/scenes/networkXSiteAbility.py
+++ b/scenes/networkXSiteAbility.py
@@ -1,10 +1,17 @@
 import re
+import warnings
 import string
 import dateparser
 import scrapy
 
 from tpdb.BaseSceneScraper import BaseSceneScraper
 from tpdb.items import SceneItem
+
+# Ignore dateparser warnings regarding pytz
+warnings.filterwarnings(
+    "ignore",
+    message="The localize method is no longer necessary, as this time zone supports the fold attribute",
+)
 
 
 class NetworkXSiteAbilitySpider(BaseSceneScraper):

--- a/scenes/siteALSAngels.py
+++ b/scenes/siteALSAngels.py
@@ -1,9 +1,16 @@
 import re
+import warnings
 import scrapy
 import dateparser
 
 from tpdb.BaseSceneScraper import BaseSceneScraper
 from tpdb.items import SceneItem
+
+# Ignore dateparser warnings regarding pytz
+warnings.filterwarnings(
+    "ignore",
+    message="The localize method is no longer necessary, as this time zone supports the fold attribute",
+)
 
 # All the videos are on one long, page, but the logic should handle the
 # normal "limit_pages" values

--- a/scenes/siteATKGirlfriends.py
+++ b/scenes/siteATKGirlfriends.py
@@ -1,5 +1,6 @@
 import re
 import json
+import warnings
 import base64
 import requests
 import dateparser
@@ -8,6 +9,12 @@ from scrapy.http import HtmlResponse
 
 from tpdb.BaseSceneScraper import BaseSceneScraper
 from tpdb.items import SceneItem
+
+# Ignore dateparser warnings regarding pytz
+warnings.filterwarnings(
+    "ignore",
+    message="The localize method is no longer necessary, as this time zone supports the fold attribute",
+)
 
 
 class ATKGirlfriendsSpider(BaseSceneScraper):

--- a/scenes/siteATKKingdom.py
+++ b/scenes/siteATKKingdom.py
@@ -1,6 +1,7 @@
 import re
 import json
 import base64
+import warnings
 import requests
 import dateparser
 import scrapy
@@ -8,6 +9,12 @@ from scrapy.http import HtmlResponse
 
 from tpdb.BaseSceneScraper import BaseSceneScraper
 from tpdb.items import SceneItem
+
+# Ignore dateparser warnings regarding pytz
+warnings.filterwarnings(
+    "ignore",
+    message="The localize method is no longer necessary, as this time zone supports the fold attribute",
+)
 
 
 class ATKKingdomSpider(BaseSceneScraper):

--- a/scenes/siteAuntJudys.py
+++ b/scenes/siteAuntJudys.py
@@ -1,10 +1,10 @@
-import scrapy
 import re
+import scrapy
 
 from tpdb.BaseSceneScraper import BaseSceneScraper
 
 
-class siteAuntJudysSpider(BaseSceneScraper):
+class SiteAuntJudysSpider(BaseSceneScraper):
     name = 'AuntJudys'
     network = 'Aunt Judys'
     parent = 'Aunt Judys'
@@ -20,7 +20,7 @@ class siteAuntJudysSpider(BaseSceneScraper):
         'image': '//span[@class="model_update_thumb"]/img/@src',
         'performers': '//div[@class="gallery_info"]/p/span[@class="update_models"]/a/text()',
         'tags': '//div[@class="gallery_info"]/span[@class="update_tags"]/a/text()',
-        'external_id': '.*\/(.*?).html',
+        'external_id': r'.*/(.*?).html',
         'trailer': '//script[contains(text(),"df_movie")]/text()',
         're_trailer': '.*df_movie.*?path:\"(.*?.mp4)\"',
         'pagination': '/tour/categories/movies_%s_d.html'
@@ -40,7 +40,7 @@ class siteAuntJudysSpider(BaseSceneScraper):
                 image = "https://www.auntjudys.com" + image.strip()
             else:
                 image = ""
-                
+
             scene = scene.xpath('./a/@href').get()
             if re.search(self.get_selector_map('external_id'), scene):
                 yield scrapy.Request(url=self.format_link(response, scene), callback=self.parse_scene, meta={'image': image})
@@ -50,7 +50,6 @@ class siteAuntJudysSpider(BaseSceneScraper):
 
     def get_parent(self, response):
         return "Aunt Judys"
-        
 
     def get_trailer(self, response):
         if 'trailer' in self.get_selector_map() and self.get_selector_map('trailer'):
@@ -62,7 +61,6 @@ class siteAuntJudysSpider(BaseSceneScraper):
                     return trailer
 
         return ''
-
 
     def get_id(self, response):
         if 'external_id' in self.regex and self.regex['external_id']:

--- a/scenes/siteAussieAss.py
+++ b/scenes/siteAussieAss.py
@@ -1,8 +1,15 @@
 import re
+import warnings
 import dateparser
 
 from tpdb.BaseSceneScraper import BaseSceneScraper
 from tpdb.items import SceneItem
+
+# Ignore dateparser warnings regarding pytz
+warnings.filterwarnings(
+    "ignore",
+    message="The localize method is no longer necessary, as this time zone supports the fold attribute",
+)
 
 
 class AussieAssSpider(BaseSceneScraper):
@@ -65,7 +72,8 @@ class AussieAssSpider(BaseSceneScraper):
                 if "aussiepov" in response.url:
                     item['image'] = "https://aussiepov.com/" + image.strip()
             else:
-                item['image'] = ''
+                item['image'] = None
+            item['image_blob'] = None
 
             performers = child.xpath('.//span[@class="update_models"]/a/text()').getall()
             if performers:

--- a/scenes/siteBamVisions.py
+++ b/scenes/siteBamVisions.py
@@ -1,11 +1,10 @@
-import dateparser
-import scrapy
 import re
+import scrapy
 
 from tpdb.BaseSceneScraper import BaseSceneScraper
 
 
-class siteBAMVisionsSpider(BaseSceneScraper):
+class SiteBAMVisionsSpider(BaseSceneScraper):
     name = 'BAMVisions'
     network = 'BAM Visions'
     parent = 'BAM Visions'
@@ -22,7 +21,7 @@ class siteBAMVisionsSpider(BaseSceneScraper):
         'date': '//li/i[@class="fa fa-calendar"]/following-sibling::strong/following-sibling::text()',
         'image': '//script[contains(text(),"poster")]/text()',
         'tags': '//meta[@name="keywords"]/@content',
-        'external_id': 'trailers\/(.*)\.html',
+        'external_id': r'trailers/(.*)\.html',
         'trailer': '//script[contains(text(),"poster")]/text()',
         'pagination': '/categories/movies/%s/latest/'
     }
@@ -32,23 +31,21 @@ class siteBAMVisionsSpider(BaseSceneScraper):
         for scene in scenes:
             yield scrapy.Request(url=self.format_link(response, scene), callback=self.parse_scene, meta={'site': 'BAM Visions'})
 
-
     def get_image(self, response):
         image = self.process_xpath(response, self.get_selector_map('image')).get()
         if image:
-            image = re.search('poster=\"(.*.jpg)\"',image).group(1)
+            image = re.search(r'poster=\"(.*.jpg)\"', image).group(1)
             if image:
                 image = "https://tour.bamvisions.com/" + image
                 return self.format_link(response, image)
         return ''
-        
 
     def get_trailer(self, response):
         trailer = self.process_xpath(response, self.get_selector_map('trailer')).get()
         if trailer:
-            trailer = re.search('video\ src=\"(.*.mp4)\"',trailer).group(1)
+            trailer = re.search(r'video\ src=\"(.*.mp4)\"', trailer).group(1)
             if trailer:
                 trailer = "https://tour.bamvisions.com/" + trailer
-                trailer = trailer.replace(" ","%20")
+                trailer = trailer.replace(" ", "%20")
                 return self.format_link(response, trailer)
-        return ''    
+        return ''

--- a/scenes/siteBamVisionsBTS.py
+++ b/scenes/siteBamVisionsBTS.py
@@ -1,11 +1,10 @@
-import dateparser
-import scrapy
 import re
+import scrapy
 
 from tpdb.BaseSceneScraper import BaseSceneScraper
 
 
-class siteBAMVisionsBTSSpider(BaseSceneScraper):
+class SiteBAMVisionsBTSSpider(BaseSceneScraper):
     name = 'BAMVisionsBTS'
     network = 'BAM Visions'
     parent = 'BAM Visions'
@@ -22,7 +21,7 @@ class siteBAMVisionsBTSSpider(BaseSceneScraper):
         'date': '//li/i[@class="fa fa-calendar"]/following-sibling::strong/following-sibling::text()',
         'image': '//script[contains(text(),"poster")]/text()',
         'tags': '//meta[@name="keywords"]/@content',
-        'external_id': 'trailers\/(.*)\.html',
+        'external_id': r'trailers/(.*)\.html',
         'trailer': '//script[contains(text(),"poster")]/text()',
         'pagination': '/categories/BTS/%s/latest/'
     }
@@ -32,23 +31,21 @@ class siteBAMVisionsBTSSpider(BaseSceneScraper):
         for scene in scenes:
             yield scrapy.Request(url=self.format_link(response, scene), callback=self.parse_scene, meta={'site': 'BAM Visions'})
 
-
     def get_image(self, response):
         image = self.process_xpath(response, self.get_selector_map('image')).get()
         if image:
-            image = re.search('poster=\"(.*.jpg)\"',image).group(1)
+            image = re.search(r'poster=\"(.*.jpg)\"', image).group(1)
             if image:
                 image = "https://tour.bamvisions.com/" + image
                 return self.format_link(response, image)
         return ''
-        
 
     def get_trailer(self, response):
         trailer = self.process_xpath(response, self.get_selector_map('trailer')).get()
         if trailer:
-            trailer = re.search('video\ src=\"(.*.mp4)\"',trailer).group(1)
+            trailer = re.search(r'video\ src=\"(.*.mp4)\"', trailer).group(1)
             if trailer:
                 trailer = "https://tour.bamvisions.com/" + trailer
-                trailer = trailer.replace(" ","%20")
+                trailer = trailer.replace(" ", "%20")
                 return self.format_link(response, trailer)
-        return ''    
+        return ''

--- a/scenes/siteBangBros.py
+++ b/scenes/siteBangBros.py
@@ -1,6 +1,13 @@
+import warnings
 import scrapy
 import dateparser
 from tpdb.BaseSceneScraper import BaseSceneScraper
+
+# Ignore dateparser warnings regarding pytz
+warnings.filterwarnings(
+    "ignore",
+    message="The localize method is no longer necessary, as this time zone supports the fold attribute",
+)
 
 
 class BangBrosSpider(BaseSceneScraper):

--- a/scenes/siteBiGuysFuck.py
+++ b/scenes/siteBiGuysFuck.py
@@ -1,4 +1,5 @@
 import re
+import warnings
 import json
 import html
 import dateparser
@@ -6,6 +7,12 @@ import scrapy
 
 from tpdb.BaseSceneScraper import BaseSceneScraper
 from tpdb.items import SceneItem
+
+# Ignore dateparser warnings regarding pytz
+warnings.filterwarnings(
+    "ignore",
+    message="The localize method is no longer necessary, as this time zone supports the fold attribute",
+)
 
 
 class BiGuysFuckSpider(BaseSceneScraper):

--- a/scenes/siteBiGuysFuck.py
+++ b/scenes/siteBiGuysFuck.py
@@ -46,8 +46,6 @@ class BiGuysFuckSpider(BaseSceneScraper):
 
     def parse_scene(self, response):
         item = SceneItem()
-        global json
-
         jsondata = response.xpath('//script[@type="application/ld+json"]/text()').get()
         jsondata = jsondata.replace("\r\n", "")
         try:

--- a/scenes/siteBoundHoneys.py
+++ b/scenes/siteBoundHoneys.py
@@ -1,9 +1,16 @@
 import re
 import html
+import warnings
 import dateparser
 import scrapy
 
 from tpdb.BaseSceneScraper import BaseSceneScraper
+
+# Ignore dateparser warnings regarding pytz
+warnings.filterwarnings(
+    "ignore",
+    message="The localize method is no longer necessary, as this time zone supports the fold attribute",
+)
 
 
 class SiteBoundHoneysSpider(BaseSceneScraper):

--- a/scenes/siteBoxTruckSex.py
+++ b/scenes/siteBoxTruckSex.py
@@ -1,11 +1,10 @@
-import scrapy
 import re
-import html
+import scrapy
 
 from tpdb.BaseSceneScraper import BaseSceneScraper
 
 
-class siteBoxTruckSexSpider(BaseSceneScraper):
+class SiteBoxTruckSexSpider(BaseSceneScraper):
     name = 'BoxTruckSex'
     network = 'Box Truck Sex'
     parent = 'Box Truck Sex'
@@ -22,7 +21,7 @@ class siteBoxTruckSexSpider(BaseSceneScraper):
         'image': '//div/img[contains(@class,"fp-splash")]/@data-orig-src',
         'performers': '//h5/a[contains(@href,"/models/")]/text()',
         'tags': '//h5/a[contains(@href,"/categories/")]/text()',
-        'external_id': '.*\/(.*).html',
+        'external_id': r'.*/(.*).html',
         'trailer': '',
         'pagination': '/tour/categories/videos_%s_d.html'
     }
@@ -35,19 +34,19 @@ class siteBoxTruckSexSpider(BaseSceneScraper):
                 image = "https://www.boxtrucksex.com/" + image.strip()
             else:
                 image = ''
-                
+
             performers = scene.xpath('.//i[contains(@class,"icon-female")]/following-sibling::text()').get()
             if performers:
                 if "," in performers:
                     performers = performers.split(",")
                 else:
                     performers = [performers]
-                    
+
             if performers:
                 performers = list(map(lambda x: x.strip().title(), performers))
             else:
                 performers = []
-                
+
             scene = scene.xpath('./@href').get()
             if re.search(self.get_selector_map('external_id'), scene):
                 yield scrapy.Request(url=self.format_link(response, scene), callback=self.parse_scene, meta={'image': image, 'performers': performers})
@@ -57,13 +56,12 @@ class siteBoxTruckSexSpider(BaseSceneScraper):
 
     def get_parent(self, response):
         return "Box Truck Sex"
-        
 
     def get_trailer(self, response):
         if 'trailer' in self.get_selector_map() and self.get_selector_map('trailer'):
             trailer = self.process_xpath(response, self.get_selector_map('trailer'))
             if trailer:
                 trailer = self.get_from_regex(trailer.get(), 're_trailer')
-                return trailer.replace(" ", "%20").replace("\\","")
+                return trailer.replace(" ", "%20").replace("\\", "")
 
-        return ''        
+        return ''

--- a/scenes/siteBrickYates.py
+++ b/scenes/siteBrickYates.py
@@ -1,11 +1,10 @@
-import scrapy
 import re
-import dateparser
 import html
+import scrapy
 from tpdb.BaseSceneScraper import BaseSceneScraper
 
 
-class siteBrickYatesSpider(BaseSceneScraper):
+class SiteBrickYatesSpider(BaseSceneScraper):
     name = 'BrickYates'
     network = 'Brick Yates'
     parent = 'Brick Yates'
@@ -21,7 +20,7 @@ class siteBrickYatesSpider(BaseSceneScraper):
         'image': '//meta[@property="og:image"]/@content',
         'performers': '//li[@class="update_models"]/a/text()',
         'tags': '//div[contains(@class,"featuring")]/ul/li/a[contains(@href,"/categories/")]/text()',
-        'external_id': '.*\/(.*?).html',
+        'external_id': r'.*/(.*?).html',
         'trailer': '',
         'pagination': '/tour/categories/Movies/%s/latest/'
     }
@@ -34,12 +33,12 @@ class siteBrickYatesSpider(BaseSceneScraper):
                 image = scene.xpath('./a/img/@src0_2x').get()
             if not image:
                 image = scene.xpath('./a/img/@src0_1x').get()
-            
+
             if image:
                 image = "https://www.brickyates.com" + image
             else:
                 image = ''
-                
+
             scene = scene.xpath('.//a[not(contains(@href,"signup"))]/@href').get()
             if re.search(self.get_selector_map('external_id'), scene):
                 yield scrapy.Request(url=self.format_link(response, scene), callback=self.parse_scene, meta={'image': image})
@@ -54,7 +53,6 @@ class siteBrickYatesSpider(BaseSceneScraper):
                 return search.group(1).lower()
         return None
 
-
     def get_description(self, response):
         description = self.process_xpath(response, self.get_selector_map('description')).getall()
         if description:
@@ -62,7 +60,7 @@ class siteBrickYatesSpider(BaseSceneScraper):
             return html.unescape(description.strip())
 
         return ''
- 
+
     def get_trailer(self, response):
         if 'trailer' in self.get_selector_map() and self.get_selector_map('trailer'):
             trailer = self.process_xpath(response, self.get_selector_map('trailer'))
@@ -71,7 +69,7 @@ class siteBrickYatesSpider(BaseSceneScraper):
                 trailer = "https://www.brandnewamateurs.com" + trailer
                 return trailer.replace(" ", "%20")
 
-        return ''    
+        return ''
 
     def get_image(self, response):
         return ''

--- a/scenes/siteChastityBabes.py
+++ b/scenes/siteChastityBabes.py
@@ -1,7 +1,14 @@
 import html
 import re
+import warnings
 import dateparser
 import scrapy
+
+# Ignore dateparser warnings regarding pytz
+warnings.filterwarnings(
+    "ignore",
+    message="The localize method is no longer necessary, as this time zone supports the fold attribute",
+)
 
 from tpdb.BaseSceneScraper import BaseSceneScraper
 from tpdb.items import SceneItem

--- a/scenes/siteChastityBabes.py
+++ b/scenes/siteChastityBabes.py
@@ -4,14 +4,14 @@ import warnings
 import dateparser
 import scrapy
 
+from tpdb.BaseSceneScraper import BaseSceneScraper
+from tpdb.items import SceneItem
+
 # Ignore dateparser warnings regarding pytz
 warnings.filterwarnings(
     "ignore",
     message="The localize method is no longer necessary, as this time zone supports the fold attribute",
 )
-
-from tpdb.BaseSceneScraper import BaseSceneScraper
-from tpdb.items import SceneItem
 
 
 class ChastityBabesFullImportSpider(BaseSceneScraper):

--- a/scenes/siteClaudiaMarie.py
+++ b/scenes/siteClaudiaMarie.py
@@ -1,10 +1,17 @@
 import re
+import warnings
 import string
 import html
 import dateparser
 
 from tpdb.BaseSceneScraper import BaseSceneScraper
 from tpdb.items import SceneItem
+
+# Ignore dateparser warnings regarding pytz
+warnings.filterwarnings(
+    "ignore",
+    message="The localize method is no longer necessary, as this time zone supports the fold attribute",
+)
 
 
 class SiteClaudiaMarieSpider(BaseSceneScraper):

--- a/scenes/siteClubSeventeen.py
+++ b/scenes/siteClubSeventeen.py
@@ -1,8 +1,15 @@
 import re
+import warnings
 import dateparser
 import scrapy
 
 from tpdb.BaseSceneScraper import BaseSceneScraper
+
+# Ignore dateparser warnings regarding pytz
+warnings.filterwarnings(
+    "ignore",
+    message="The localize method is no longer necessary, as this time zone supports the fold attribute",
+)
 
 
 class ClubseventeenSpider(BaseSceneScraper):

--- a/scenes/siteCosmid.py
+++ b/scenes/siteCosmid.py
@@ -1,4 +1,5 @@
 import re
+import warnings
 import html
 import string
 import dateparser
@@ -6,6 +7,12 @@ import scrapy
 
 from tpdb.BaseSceneScraper import BaseSceneScraper
 from tpdb.items import SceneItem
+
+# Ignore dateparser warnings regarding pytz
+warnings.filterwarnings(
+    "ignore",
+    message="The localize method is no longer necessary, as this time zone supports the fold attribute",
+)
 
 
 class CosmidFullImportSpider(BaseSceneScraper):

--- a/scenes/siteCospuri.py
+++ b/scenes/siteCospuri.py
@@ -1,10 +1,17 @@
-import scrapy
 import re
+import warnings
 import dateparser
+import scrapy
 from tpdb.BaseSceneScraper import BaseSceneScraper
 
+# Ignore dateparser warnings regarding pytz
+warnings.filterwarnings(
+    "ignore",
+    message="The localize method is no longer necessary, as this time zone supports the fold attribute",
+)
 
-class siteCospuriSpider(BaseSceneScraper):
+
+class SiteCospuriSpider(BaseSceneScraper):
     name = 'Cospuri'
     network = 'Cospuri'
     parent = 'Cospuri'
@@ -23,15 +30,14 @@ class siteCospuriSpider(BaseSceneScraper):
         'description': '//div[@class="description"]/text()',
         'date': '//div[@class="date"]/text()',
         'image': '//div[@class="vid cosplay"]/div/@style',
-        're_image': '\((http.*.jpg)\)',
+        're_image': r'\((http.*.jpg)\)',
         'performers': '//div[@class="sample-model"]/a/text()',
         'tags': '//div[@class="tags"]/a/text()',
         'external_id': 'id=(.*)',
         'trailer': '//script[contains(text(),"sources")]/text()',
-        're_trailer': '(https.*\.mp4)',
+        're_trailer': r'(https.*\.mp4)',
         'pagination': '/samples?channel=cosplay&page=%s'
     }
-    
 
     def start_requests(self):
         for pagination in self.paginations:
@@ -62,7 +68,7 @@ class siteCospuriSpider(BaseSceneScraper):
                                          cookies=self.cookies)
 
     def get_next_page_url(self, url, page, pagination):
-        return self.format_url(url, pagination % page)    
+        return self.format_url(url, pagination % page)
 
     def get_scenes(self, response):
         scenes = response.xpath('//div[@class="scene cosplay"]/div/a/@href').getall()
@@ -72,17 +78,15 @@ class siteCospuriSpider(BaseSceneScraper):
 
     def get_site(self, response):
         return "Cospuri"
-        
 
     def get_parent(self, response):
         return "Cospuri"
-
 
     def get_date(self, response):
         date = self.process_xpath(response, self.get_selector_map('date')).get()
         if date:
             # ~ print(f'Date: {date}')
-            dates = re.search('(\d{4}).*?(\d{2}).*?(\d{2})', date)
+            dates = re.search(r'(\d{4}).*?(\d{2}).*?(\d{2})', date)
             if dates:
                 year = dates.group(1)
                 month = dates.group(2)

--- a/scenes/siteCruelFuries.py
+++ b/scenes/siteCruelFuries.py
@@ -1,21 +1,19 @@
-import dateparser
 import scrapy
-
 from tpdb.BaseSceneScraper import BaseSceneScraper
 
 
-class siteCruelFuriesSpider(BaseSceneScraper):
+class SiteCruelFuriesSpider(BaseSceneScraper):
     name = 'CruelFuries'
     network = 'Cruel Furies'
 
     start_urls = [
         'https://www.cruel-furies.com',
     ]
-    
-    cookies =  {
+
+    cookies = {
         'fury_site_accepted': 'eyJpdiI6InphQ3pBcXp3MmFDV1lRNFEySVwvT2NnPT0iLCJ2YWx1ZSI6Ikg0WkhUK2dONHhPSzlOY1dHVGNXZEE9PSIsIm1hYyI6ImIwOTAxNjljNDI1Yzc2M2UyNzFhNzQwMDQzNzM1ZmRjOTY4MDczNDc5YWZlNWRlMGYyNjliZTg5MDhlNGRiMzcifQ',
     }
-    
+
     selector_map = {
         'title': '//div[contains(@class,"model-info")]/h3/text()',
         'description': '//div[contains(@class,"model-info")]/p[contains(@class,"mt-4")]/preceding-sibling::p[1]/text()',
@@ -24,7 +22,7 @@ class siteCruelFuriesSpider(BaseSceneScraper):
         'date_formats': ['%Y-%m-%d'],
         'image': '//meta[@property="og:image"]/@content',
         'tags': '//meta[@name="keywords"]/@content',
-        'external_id': '(\d+)$',
+        'external_id': r'(\d+)$',
         'trailer': '//video/source/@src',
         'pagination': '/list/%s',
     }
@@ -36,7 +34,7 @@ class siteCruelFuriesSpider(BaseSceneScraper):
                              meta={'page': self.page},
                              headers=self.headers,
                              cookies=self.cookies)
-    
+
     def start_requests2(self, response):
         for link in self.start_urls:
             yield scrapy.Request(url=self.get_next_page_url(link, self.page),
@@ -52,7 +50,7 @@ class siteCruelFuriesSpider(BaseSceneScraper):
 
     def get_site(self, response):
         return "Cruel Furies"
-   
+
     def get_parent(self, response):
         return "Cruel Furies"
 

--- a/scenes/siteCruelGirlfriend.py
+++ b/scenes/siteCruelGirlfriend.py
@@ -1,10 +1,17 @@
 import re
+import warnings
 import string
 import html
 import dateparser
 import scrapy
 
 from tpdb.BaseSceneScraper import BaseSceneScraper
+
+# Ignore dateparser warnings regarding pytz
+warnings.filterwarnings(
+    "ignore",
+    message="The localize method is no longer necessary, as this time zone supports the fold attribute",
+)
 
 
 class SiteCruelGirlfriendSpider(BaseSceneScraper):

--- a/scenes/siteCumBuffet.py
+++ b/scenes/siteCumBuffet.py
@@ -1,10 +1,17 @@
-import scrapy
 import re
+import warnings
 import dateparser
+import scrapy
 from tpdb.BaseSceneScraper import BaseSceneScraper
 
+# Ignore dateparser warnings regarding pytz
+warnings.filterwarnings(
+    "ignore",
+    message="The localize method is no longer necessary, as this time zone supports the fold attribute",
+)
 
-class siteCumBuffetSpider(BaseSceneScraper):
+
+class SiteCumBuffetSpider(BaseSceneScraper):
     name = 'CumBuffet'
     network = 'Cum Buffet'
     parent = 'Cum Buffet'
@@ -18,23 +25,21 @@ class siteCumBuffetSpider(BaseSceneScraper):
         'description': '',
         'date': '',
         'image': '//div[@class="vp"]/div[contains(@class,"player")]/@style',
-        're_image': '(http.*\.jpg)',
+        're_image': r'(http.*\.jpg)',
         'performers': '//div[contains(@class,"tags")]/a[contains(@href,"/girl/")]/text()',
         'tags': '//div[contains(@class,"tags")]/ul/li/a/text()',
-        'external_id': 'sample\/(.*?)\/',
+        'external_id': r'sample/(.*?)/',
         'trailer': '//video/source/@src',
         'pagination': '/categories/movies_%s_d.html#'
     }
 
-
     def start_requests(self):
-        for link in self.start_urls:
-            yield scrapy.Request(url="https://www.cumbuffet.com/samples",
-                                 callback=self.get_scenes,
-                                 meta={'page': self.page},
-                                 headers=self.headers,
-                                 cookies=self.cookies)
-                                 
+        yield scrapy.Request(url="https://www.cumbuffet.com/samples",
+                             callback=self.get_scenes,
+                             meta={'page': self.page},
+                             headers=self.headers,
+                             cookies=self.cookies)
+
     def get_scenes(self, response):
         meta = response.meta
         scenes = response.xpath('//div[@class="video"]')
@@ -53,8 +58,6 @@ class siteCumBuffetSpider(BaseSceneScraper):
 
     def get_parent(self, response):
         return "Cum Buffet"
-        
+
     def get_description(self, response):
         return ''
-        
-        

--- a/scenes/siteFemjoy.py
+++ b/scenes/siteFemjoy.py
@@ -1,8 +1,15 @@
+import warnings
 import json
 import dateparser
 
 from tpdb.BaseSceneScraper import BaseSceneScraper
 from tpdb.items import SceneItem
+
+# Ignore dateparser warnings regarding pytz
+warnings.filterwarnings(
+    "ignore",
+    message="The localize method is no longer necessary, as this time zone supports the fold attribute",
+)
 
 
 class SiteFemjoySpider(BaseSceneScraper):
@@ -27,7 +34,6 @@ class SiteFemjoySpider(BaseSceneScraper):
     }
 
     def get_scenes(self, response):
-        global json
         itemlist = []
         jsondata = json.loads(response.text)
         data = jsondata['results']
@@ -64,5 +70,4 @@ class SiteFemjoySpider(BaseSceneScraper):
 
     def get_next_page_url(self, base, page):
         url = self.format_url(base, self.get_selector_map('pagination').format(page))
-        print(url)
         return url

--- a/scenes/siteIntTheCrack.py
+++ b/scenes/siteIntTheCrack.py
@@ -6,6 +6,7 @@
 
 import os
 import re
+import warnings
 import json
 import base64
 import datetime
@@ -16,6 +17,12 @@ from scrapy.http import HtmlResponse
 
 from tpdb.BaseSceneScraper import BaseSceneScraper
 from tpdb.items import SceneItem
+
+# Ignore dateparser warnings regarding pytz
+warnings.filterwarnings(
+    "ignore",
+    message="The localize method is no longer necessary, as this time zone supports the fold attribute",
+)
 
 
 class InTheCrackSpider(BaseSceneScraper):

--- a/scenes/sitePornDudeCasting.py
+++ b/scenes/sitePornDudeCasting.py
@@ -1,9 +1,16 @@
 import re
+import warnings
 import html
 import dateparser
 import scrapy
 
 from tpdb.BaseSceneScraper import BaseSceneScraper
+
+# Ignore dateparser warnings regarding pytz
+warnings.filterwarnings(
+    "ignore",
+    message="The localize method is no longer necessary, as this time zone supports the fold attribute",
+)
 
 
 class SitePornDudeCastingSpider(BaseSceneScraper):

--- a/scenes/siteRubberPassion.py
+++ b/scenes/siteRubberPassion.py
@@ -1,9 +1,16 @@
 import re
+import warnings
 import string
 import dateparser
 import scrapy
 
 from tpdb.BaseSceneScraper import BaseSceneScraper
+
+# Ignore dateparser warnings regarding pytz
+warnings.filterwarnings(
+    "ignore",
+    message="The localize method is no longer necessary, as this time zone supports the fold attribute",
+)
 
 
 class SiteRubberPassionSpider(BaseSceneScraper):

--- a/scenes/siteThisIsGlamour.py
+++ b/scenes/siteThisIsGlamour.py
@@ -1,10 +1,17 @@
 import re
+import warnings
 import string
 import base64
 import requests
 import dateparser
 from tpdb.BaseSceneScraper import BaseSceneScraper
 from tpdb.items import SceneItem
+
+# Ignore dateparser warnings regarding pytz
+warnings.filterwarnings(
+    "ignore",
+    message="The localize method is no longer necessary, as this time zone supports the fold attribute",
+)
 
 
 class SiteThisIsGlamourSpider(BaseSceneScraper):

--- a/scenes/siteXArt.py
+++ b/scenes/siteXArt.py
@@ -1,12 +1,10 @@
 import re
-
-import dateparser
 import scrapy
 
 from tpdb.BaseSceneScraper import BaseSceneScraper
 
 
-class siteXArtSpider(BaseSceneScraper):
+class SiteXArtSpider(BaseSceneScraper):
     name = 'X-Art'
     network = "BC Media"
     parent = "X-Art"
@@ -22,7 +20,7 @@ class siteXArtSpider(BaseSceneScraper):
         'image': '//div[contains(@class, "video-tour")]/div/a/img/@src',
         'performers': '//div[@class="row"]/div[contains(@class,"columns info")]/h2/span[contains(text(),"eaturing")]/following-sibling::a/text()',
         'tags': '',
-        'external_id': '.*\/(.*)\/$',
+        'external_id': r'.*/(.*)\/$',
         'trailer': '',
         'pagination': '/videos/recent/%s'
     }
@@ -39,7 +37,7 @@ class siteXArtSpider(BaseSceneScraper):
     def get_id(self, response):
         search = re.search(self.get_selector_map('external_id'), response.url, re.IGNORECASE)
         search = search.group(1)
-        search = search.replace("_","-").strip()
+        search = search.replace("_", "-").strip()
         return search
 
     def get_description(self, response):

--- a/scenes/siteYanks.py
+++ b/scenes/siteYanks.py
@@ -1,11 +1,18 @@
+import re
+import warnings
 import string
 import html
-import re
 from datetime import date
 import dateparser
 
 from tpdb.BaseSceneScraper import BaseSceneScraper
 from tpdb.items import SceneItem
+
+# Ignore dateparser warnings regarding pytz
+warnings.filterwarnings(
+    "ignore",
+    message="The localize method is no longer necessary, as this time zone supports the fold attribute",
+)
 
 
 class SiteYanksSpider(BaseSceneScraper):


### PR DESCRIPTION
It's in the commit comment, but Python 3.8 gives a warning with the current version of dateparser.  The only fix I've found for it is to tell the script to ignore that warning.