### PR TITLE
Created Smart Media Star Scene & Performer parser

### DIFF
--- a/performers/networkSmartMediaStar.py
+++ b/performers/networkSmartMediaStar.py
@@ -1,0 +1,60 @@
+import scrapy
+
+from tpdb.BasePerformerScraper import BasePerformerScraper
+
+
+class SmartMediaStarPerformerSpider(BasePerformerScraper):
+    name = 'SmartMediaStarPerformer'
+    network = 'Smart Media Star'
+    parent = 'Smart Media Star'
+
+    start_urls = [
+        'https://realitylovers.com/',
+        'https://tsvirtuallovers.com'
+    ]
+
+    limit_pages = 30
+
+    selector_map = {
+        'name': '//h1[contains(@class,"girlDetails-title")]/text()',
+        'image': '//img[contains(@class,"girlDetails-posterImage")]/@srcset',
+        'image_blob': True,
+        'bio': '//p[contains(@class,"girlDetails-bioText")]//text()',
+        'birthday': '//b[contains(text(),"Birthday")]/../following-sibling::dd[1]/text()',
+        'birthplace': '//b[contains(text(),"Country")]/../following-sibling::dd[1]/text()',
+        'cupsize': '//b[contains(text(),"Cup")]/../following-sibling::dd[1]/text()',
+        'height': '//b[contains(text(),"Height")]/../following-sibling::dd[1]/text()',
+        're_height': r'[^\(]+\(([^\)]+)\)',
+        'weight': '//b[contains(text(),"Weight")]/../following-sibling::dd[1]/text()',
+        're_weight': r'[^\(]+\(([^\)]+)\)',
+        'pagination': 'girls/page%s',
+        'external_id': r'girl\/([0-9]+)\/'
+    }
+
+    site_genders = {
+        'realitylovers': "Female",
+        'tsvirtuallovers': "Trans"
+    }
+
+    def get_gender(self, response):
+        site = super().get_site(response)
+        return self.site_genders[site]
+
+    def get_performers(self, response):
+        performers = response.xpath('//a[contains(@class,"girlsCategory-girlItem")]/@href').getall()
+        for performer in performers:
+            yield scrapy.Request(url=self.format_link(response, performer), callback=self.parse_performer, cookies=self.cookies, headers=self.headers)
+
+    def get_image(self, response):
+        image = super().get_image(response)
+        image = self.get_main_image_from_srcset(image)
+        return image
+
+    @staticmethod
+    def get_main_image_from_srcset(srcset):
+        images = dict(map(lambda image: (image.split("%20")[1], image.split("%20")[0]), srcset.split(",")))
+        for size in ['2x', '1x']:
+            if size in images:
+                return images[size]
+
+        return None

--- a/scenes/networkSmartMediaStar.py
+++ b/scenes/networkSmartMediaStar.py
@@ -1,0 +1,151 @@
+import json
+import scrapy
+from tpdb.BaseSceneScraper import BaseSceneScraper
+
+
+class SmartMediaStarSpider(BaseSceneScraper):
+    name = 'SmartMediaStar'
+    network = 'Smart Media Star'
+    parent = 'Smart Media Star'
+
+    limit_pages = int(129/15)+1
+    per_page = 15
+
+    # Creates individual versions if multiple perspectives are found
+    split_versions = True
+    # Use perspective thumbnail instead of main thumbnail found on /videos page
+    use_perspective_thumbnail = False
+    # Always add (<perspective>) to video title regardless of whether perspective is main perspective
+    always_label_perspective = False
+
+    start_urls = [
+        # 'https://realitylovers.com',
+        'https://tsvirtuallovers.com'
+    ]
+
+    selector_map = {
+        'description': '//p[@itemprop="description"]//text()',
+        'performers': '//a[@itemprop="actor"]/text()',
+        'tags': '//a[@itemprop="keyword"]/text()',
+        're_scene_data': r'const sceneData = (\{[^;]+)\;',
+        'external_id': r'\/vd\/([0-9]+)\/',
+        'pagination': '',
+        'type': 'Scene',
+    }
+
+    sites = {
+        'realitylovers': "Reality Lovers",
+        'tsvirtuallovers': "TS Virtual Lovers"
+    }
+
+    def start_requests(self):
+        for link in self.start_urls:
+            yield scrapy.Request(
+                url=f"{link}/videos/search",
+                callback=self.parse,
+                method='POST',
+                headers={'Content-Type': 'application/json', 'Referer': f"{link}/videos"},
+                meta={'page': self.page},
+                body=self.create_post_data(self.page, self.per_page)
+            )
+
+    def parse(self, response, **kwargs):
+        scenes = self.get_scenes(response)
+        count = 0
+        for scene in scenes:
+            count += 1
+            yield self.check_item(scene)
+
+        if count:
+            if 'page' in response.meta and response.meta['page'] < self.limit_pages:
+                meta = response.meta
+                meta['page'] = meta['page'] + 1
+                print('NEXT PAGE: ' + str(meta['page']))
+                yield scrapy.Request(url=response.url,
+                                     callback=self.parse,
+                                     meta=meta,
+                                     method="POST",
+                                     body=self.create_post_data(meta['page'], self.per_page),
+                                     headers={'Content-Type': 'application/json'},
+                                     cookies=self.cookies)
+
+    def get_scenes(self, response):
+        meta = response.meta
+        scenes = response.json()['contents']
+        for scene in scenes:
+            meta['id'] = scene['id']
+            meta['title'] = scene['title']
+            meta['date'] = self.parse_date(scene['released']).isoformat()
+            meta['image'] = self.get_main_image_from_srcset(scene['mainImageSrcset'])
+
+            url = scene['videoUri']
+            yield scrapy.Request(url=self.format_link(response, url), callback=self.parse_scene, meta=meta)
+
+    def parse_scene(self, response, **kwargs):
+        item = next(super().parse_scene(response, **kwargs))
+
+        if self.split_versions:
+            scenedata = self.get_scene_data(response)
+
+            for scene in scenedata:
+                localitem = item.copy()
+
+                localitem['id'] = scene['id']
+
+                if self.use_perspective_thumbnail:
+                    localitem['image'] = self.get_main_image_from_srcset(scene['imgSrcSet'])
+
+                localitem['duration'] = scene['durationSec']
+
+                if not scene['main'] or self.always_label_perspective:
+                    localitem['title'] += f" ({scene['perspective']})"
+
+                yield localitem
+        else:
+            yield item
+
+    def get_site(self, response):
+        site = super().get_site(response)
+        return self.sites[site]
+
+    def get_tags(self, response):
+        tags = super().get_tags(response)
+        if "Virtual Reality" not in tags:
+            tags.append("Virtual Reality")
+        return tags
+
+    def get_description(self, response):
+        description = super().get_description(response)
+        description = self.cleanup_description(description.replace(" … Read more", ""))
+        return description
+
+    def get_scene_data(self, response):
+        script = response.xpath('//script[contains(text(),"const sceneData")]/text()').get()
+        jsondata = self.get_from_regex(script, "re_scene_data")
+        data = json.loads(jsondata.strip())
+
+        perspectivedata = []
+        for scene in data['povScenes']:
+            scene['perspective'] = "POV"
+            scene['main'] = scene['id'] == data['firstSceneId']
+            perspectivedata.append(scene)
+
+        for scene in data['voyeurScenes']:
+            scene['perspective'] = "Voyeur"
+            scene['main'] = scene['id'] == data['firstSceneId']
+            perspectivedata.append(scene)
+
+        return perspectivedata
+
+    @staticmethod
+    def create_post_data(page, per_page):
+        return json.dumps({"searchQuery": "", "categoryId": None, "perspective": None, "actorId": None, "offset": (page-1) * per_page, "isInitialLoad": False, "sortBy": "NEWEST", "videoView": "MEDIUM", "device": "DESKTOP"})
+
+    @staticmethod
+    def get_main_image_from_srcset(srcset):
+        images = dict(map(lambda image: (image.split(" ")[1], image.split(" ")[0]), srcset.split(",")))
+        for size in ['2x', '1x']:
+            if size in images:
+                return images[size]
+
+        return None

--- a/scenes/networkSmartMediaStar.py
+++ b/scenes/networkSmartMediaStar.py
@@ -8,7 +8,6 @@ class SmartMediaStarSpider(BaseSceneScraper):
     network = 'Smart Media Star'
     parent = 'Smart Media Star'
 
-    limit_pages = int(129/15)+1
     per_page = 15
 
     # Creates individual versions if multiple perspectives are found
@@ -19,7 +18,7 @@ class SmartMediaStarSpider(BaseSceneScraper):
     always_label_perspective = False
 
     start_urls = [
-        # 'https://realitylovers.com',
+        'https://realitylovers.com',
         'https://tsvirtuallovers.com'
     ]
 

--- a/scenes/networkSmartMediaStar.py
+++ b/scenes/networkSmartMediaStar.py
@@ -138,7 +138,7 @@ class SmartMediaStarSpider(BaseSceneScraper):
 
     @staticmethod
     def create_post_data(page, per_page):
-        return json.dumps({"searchQuery": "", "categoryId": None, "perspective": None, "actorId": None, "offset": (page-1) * per_page, "isInitialLoad": False, "sortBy": "NEWEST", "videoView": "MEDIUM", "device": "DESKTOP"})
+        return json.dumps({"searchQuery": "", "categoryId": None, "perspective": None, "actorId": None, "offset": (page - 1) * per_page, "isInitialLoad": False, "sortBy": "NEWEST", "videoView": "MEDIUM", "device": "DESKTOP"})
 
     @staticmethod
     def get_main_image_from_srcset(srcset):


### PR DESCRIPTION
Performer parser is straightforward. Auto-codes to female for Reality Lovers, and trans for TS Virtual Lovers.

Scene parser has some configuration options:
`split_versions (default: True)` = if True will create separate POV & Voyeur scenes (if available). ID is matched to internal ID the sites use (it will ignore the ID in the url)
`use_perspective_thumbnail (default: False)`  = if splitting versions, this will pick the thumbnail from the perspective versus the main scene listing thumbnail
`always_label_perspective (default: False)` = if True, it will always append (POV) or (Voyeur) to the respective editions, if False, it will only label the perspective that the site considers the alternative